### PR TITLE
Add Preview repo parameter

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -19,6 +19,7 @@ group :test do
   gem 'puppetlabs_spec_helper'
   gem 'simplecov'
   gem 'metadata-json-lint'
+  gem 'rspec-puppet-facts'
 end
 
 group :development do

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -26,6 +26,9 @@
 #
 # @param service_ensure [String] What status the service should be enforced to
 #
+# @param yum_preview_repo [String] Whether to use the preview Yum repos to
+#   install package. See https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/
+#
 class cockpit (
   $logintitle     = $::cockpit::params::logintitle,
   $manage_package  = $::cockpit::params::manage_package,
@@ -34,6 +37,7 @@ class cockpit (
   $package_version = $::cockpit::params::package_version,
   $service_name    = $::cockpit::params::service_name,
   $service_ensure  = $::cockpit::params::service_ensure,
+  $yum_preview_repo = $::cockpit::params::yum_preview_repo,
 ) inherits ::cockpit::params {
 
   validate_string($logintitle)

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,6 +3,7 @@ class cockpit::params {
   case $::osfamily {
     'RedHat': {
       $manage_repo     = true
+      $yum_preview_repo = false
       $manage_package  = true
       $package_name    = 'cockpit'
       $package_version = 'installed'

--- a/manifests/repo/centos.pp
+++ b/manifests/repo/centos.pp
@@ -1,20 +1,28 @@
 class cockpit::repo::centos {
 
-  case $::operatingsystemmajrelease {
-    '7': {
-      yumrepo { 'group_cockpit-cockpit-preview':
-        ensure              => 'present',
-        baseurl             => 'https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/epel-7-$basearch/',
-        descr               => 'Copr repo for cockpit-preview owned by msuchy',
-        enabled             => '1',
-        gpgcheck            => '1',
-        gpgkey              => 'https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg',
-        skip_if_unavailable => 'True',
-      }
-    }
-    default: {
+  if $::cockpit::yum_preview_repo {
 
+    yumrepo { 'group_cockpit-cockpit-preview':
+      ensure              => 'present',
+      baseurl             => 'https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/epel-7-$basearch/',
+      descr               => 'Copr repo for cockpit-preview owned by msuchy',
+      enabled             => '1',
+      gpgcheck            => '1',
+      gpgkey              => 'https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg',
+      skip_if_unavailable => 'True',
     }
+
+  } else {
+
+    yumrepo { 'extras':
+      ensure     => 'present',
+      descr      => 'CentOS-$releasever - Extras',
+      gpgcheck   => '1',
+      enabled    => '1',
+      gpgkey     => 'file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7',
+      mirrorlist => 'http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra',
+    }
+
   }
 
 }

--- a/spec/classes/cockpit_centos_spec.rb
+++ b/spec/classes/cockpit_centos_spec.rb
@@ -1,0 +1,39 @@
+require 'spec_helper'
+
+describe 'cockpit' do
+  context 'on CentOS' do
+    let(:facts) {{
+      :osfamily                  => 'RedHat',
+      :operatingsystemmajrelease => '7',
+      :operatingsystem           => 'CentOS',
+    }}
+
+    context 'repo disabled' do
+      let(:params) {{ 'manage_repo' => false }}
+      it { should_not contain_yumrepo('extras') }
+    end
+
+    context 'repo enabled' do
+      let(:params) {{ 'manage_repo' => true }}
+      it { should contain_yumrepo('extras').with(
+        :descr    => 'CentOS-$releasever - Extras',
+        :enabled  => '1',
+        :gpgcheck => '1',
+        :gpgkey   => "file:///etc/pki/rpm-gpg/RPM-GPG-KEY-CentOS-7",
+        :mirrorlist  => "http://mirrorlist.centos.org/?release=$releasever&arch=$basearch&repo=extras&infra=$infra"
+      )}
+    end
+
+    context 'with yum_preview_repo => true' do
+      let(:params) {{ 'yum_preview_repo' => true }}
+      it { should contain_yumrepo('group_cockpit-cockpit-preview').with(
+        :descr    => 'Copr repo for cockpit-preview owned by msuchy',
+        :enabled  => '1',
+        :gpgcheck => '1',
+        :gpgkey   => "https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg",
+        :baseurl  => "https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/epel-7-$basearch/"
+        )}
+    end
+
+  end
+end

--- a/spec/classes/cockpit_spec.rb
+++ b/spec/classes/cockpit_spec.rb
@@ -1,58 +1,36 @@
 require 'spec_helper'
 
 describe 'cockpit' do
-  context 'on supported operating systems' do
-    context 'without any parameters' do
-      let(:params) {{ }}
-      let(:facts) {{
-        :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease => '7',
-        :operatingsystem           => 'CentOS',
-        :fqdn                      => 'coolserver.vm'
-      }}
-      it { should compile.with_all_deps }
 
-      it { should create_class('cockpit') }
+  shared_examples 'no parameters' do
+    let(:params) {{ }}
 
-      it { should contain_class('cockpit::params') }
-      it { should contain_class('cockpit::repo').that_comes_before('cockpit::install') }
-      it { should contain_class('cockpit::install').that_comes_before('cockpit::config') }
-      it { should contain_class('cockpit::config') }
-      it { should contain_class('cockpit::service').that_subscribes_to('cockpit::config') }
+    it { should compile.with_all_deps }
 
-      it { should contain_class('cockpit::repo::Centos') }
+    it { should create_class('cockpit') }
 
-      it { should contain_ini_setting('Cockpit LoginTitle').with(
-        :ensure    => 'present',
-        :path      => '/etc/cockpit/cockpit.conf',
-        :section   => 'WebService',
-        :setting   => 'LoginTitle',
-        :value     => 'coolserver.vm',
-        :show_diff => true,
+    it { should contain_class('cockpit::params') }
+    it { should contain_class('cockpit::repo').that_comes_before('cockpit::install') }
+    it { should contain_class('cockpit::install').that_comes_before('cockpit::config') }
+    it { should contain_class('cockpit::config') }
+    it { should contain_class('cockpit::service').that_subscribes_to('cockpit::config') }
+
+    it { should contain_ini_setting('Cockpit LoginTitle').with(
+      :ensure    => 'present',
+      :path      => '/etc/cockpit/cockpit.conf',
+      :section   => 'WebService',
+      :setting   => 'LoginTitle',
+      :value     => facts[:fqdn],
+      :show_diff => true,
       ) }
 
-      it { should contain_service('cockpit').with(
-        :ensure => 'running',
-        :enable => 'true'
+    it { should contain_service('cockpit').with(
+      :ensure => 'running',
+      :enable => 'true'
       )}
-      it { should contain_package('cockpit').with_ensure('installed') }
+    it { should contain_package('cockpit').with_ensure('installed') }
 
-      it { should contain_yumrepo('group_cockpit-cockpit-preview').with(
-        :descr    => 'Copr repo for cockpit-preview owned by msuchy',
-        :enabled  => '1',
-        :gpgcheck => '1',
-        :gpgkey   => "https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/pubkey.gpg",
-        :baseurl  => "https://copr-be.cloud.fedoraproject.org/results/@cockpit/cockpit-preview/epel-7-$basearch/"
-      )}
-
-    end
     context 'with custom parameters' do
-      let(:facts) {{
-        :osfamily                  => 'RedHat',
-        :operatingsystemmajrelease => '7',
-        :operatingsystem           => 'CentOS',
-      }}
-
       context 'package name' do
         let(:params) {{ 'package_name' => 'custom-package' }}
         it { should contain_package("#{params['package_name']}") }
@@ -61,21 +39,19 @@ describe 'cockpit' do
         let(:params) {{ 'service_name' => 'custom-service' }}
         it { should contain_service("#{params['service_name']}") }
       end
-      context 'repo disabled' do
-        let(:params) {{ 'manage_repo' => false }}
-        it { should_not contain_yumrepo('group_cockpit-cockpit-preview') }
+    end
+  end
+
+  on_supported_os.each do |os, facts|
+    context "on #{os}" do
+      let(:facts) do
+        facts.merge({
+          :fqdn => 'cockpit.example.com',
+        })
       end
 
+      it_behaves_like 'no parameters'
     end
   end
-  context 'unsupported operating system' do
-    context 'cockpit class without any parameters on Solaris/Nexenta' do
-      let(:facts) {{
-        :osfamily        => 'Solaris',
-        :operatingsystem => 'Nexenta',
-      }}
 
-      it { expect { should contain_package('cockpit') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
-    end
-  end
 end

--- a/spec/classes/cockpit_unsupported_spec.rb
+++ b/spec/classes/cockpit_unsupported_spec.rb
@@ -1,0 +1,14 @@
+require 'spec_helper'
+
+describe 'cockpit' do
+  context 'unsupported operating system' do
+    context 'cockpit class without any parameters on Solaris/Nexenta' do
+      let(:facts) {{
+        :osfamily        => 'Solaris',
+        :operatingsystem => 'Nexenta',
+      }}
+
+      it { expect { should contain_package('cockpit') }.to raise_error(Puppet::Error, /Nexenta not supported/) }
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,1 +1,3 @@
 require 'puppetlabs_spec_helper/module_spec_helper'
+require 'rspec-puppet-facts'
+include RspecPuppetFacts


### PR DESCRIPTION
 Adds `yum_preview_repo` parameter

    * Allows specifying if you want to use the preview repo to install Cockpit (See https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/)
    * Allow specifying if you want to use preview repo