### PR TITLE
Plumbing

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,9 +38,9 @@ By default, this module will:
 
 ### Beginning with cockpit
 
-On RHEL, Cockpit exists in most upstream repos by default, but you can enable
+On RHEL, Cockpit exists in most upstream repos by default, but you can also get preview releases (See https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/)
 
-On Fedora, it's already setup by default.
+On other Operating Systems, repositories are maintained seperately.
 
 Configuration is mainly configured in `/etc/cockpit/cockpit.conf`
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -29,33 +29,37 @@
 #
 # @param package_version [String] Version of the cockpit package to install
 #
-# @param service_name [String] Name of the cockpit service to manage
-#
 # @param service_ensure [String] What status the service should be enforced to
+#
+# @param service_name [String] Name of the cockpit service to manage
 #
 # @param yum_preview_repo [String] Whether to use the preview Yum repos to
 #   install package. See https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/
 #
 class cockpit (
-  $logintitle     = $::cockpit::params::logintitle,
-  $manage_package  = $::cockpit::params::manage_package,
-  $manage_repo     = $::cockpit::params::manage_repo,
-  $package_name    = $::cockpit::params::package_name,
-  $package_version = $::cockpit::params::package_version,
-  $service_name    = $::cockpit::params::service_name,
-  $service_ensure  = $::cockpit::params::service_ensure,
   $allowunencrypted = $::cockpit::params::allowunencrypted,
+  $logintitle       = $::cockpit::params::logintitle,
+  $manage_package   = $::cockpit::params::manage_package,
+  $manage_repo      = $::cockpit::params::manage_repo,
   $maxstartups      = $::cockpit::params::maxstartups,
+  $package_name     = $::cockpit::params::package_name,
+  $package_version  = $::cockpit::params::package_version,
+  $service_ensure   = $::cockpit::params::service_ensure,
+  $service_name     = $::cockpit::params::service_name,
   $yum_preview_repo = $::cockpit::params::yum_preview_repo,
 ) inherits ::cockpit::params {
 
-  validate_string($logintitle)
+
+  validate_bool($allowunencrypted)
   validate_bool($manage_package)
   validate_bool($manage_repo)
+
+  validate_string($logintitle)
+  validate_string($maxstartups)
   validate_string($package_name)
   validate_string($package_version)
-  validate_string($service_name)
   validate_string($service_ensure)
+  validate_string($service_name)
 
   class { '::cockpit::repo': } ->
   class { '::cockpit::install': } ->

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,21 +1,27 @@
 # cockpit::params - Default parameters
 class cockpit::params {
+
+  # OS Specific Defaults
   case $::osfamily {
     'RedHat': {
-      $manage_repo     = true
       $yum_preview_repo = false
-      $manage_package  = true
-      $package_name    = 'cockpit'
-      $package_version = 'installed'
-      $service_name    = 'cockpit'
-      $manage_service  = true
-      $service_ensure  = 'running'
-      $logintitle      = $::fqdn
-      $allowunencrypted = false
-      $maxstartups      = '10'
     }
     default: {
       fail("${::operatingsystem} not supported")
     }
   }
+
+  # Defaults for all Operating Systems
+  # (Cockpit has consistant naming accross OS's, hooray! :D)
+  $allowunencrypted = false
+  $logintitle       = $::fqdn
+  $manage_package   = true
+  $manage_repo      = true
+  $manage_service   = true
+  $maxstartups      = '10'
+  $package_name     = 'cockpit'
+  $package_version  = 'installed'
+  $service_ensure   = 'running'
+  $service_name     = 'cockpit'
+
 }

--- a/spec/classes/cockpit_centos_spec.rb
+++ b/spec/classes/cockpit_centos_spec.rb
@@ -15,6 +15,8 @@ describe 'cockpit' do
 
     context 'repo enabled' do
       let(:params) {{ 'manage_repo' => true }}
+      it { should contain_class('Cockpit::Repo::Centos')}
+
       it { should contain_yumrepo('extras').with(
         :descr    => 'CentOS-$releasever - Extras',
         :enabled  => '1',


### PR DESCRIPTION
Sort parameters alphabetically
* Makes things a bit easier to find

Move non-RedHat specific parameters to global
* So far the only thing that's RedHat specific is the Yum preview repos
* Everything else is the same across various distros

Adds spec to see that CentOS repo class present	