### PR TITLE
Enables service enabling for Puppet

### DIFF
--- a/manifests/service.pp
+++ b/manifests/service.pp
@@ -3,13 +3,9 @@
 class cockpit::service {
 
   if $::cockpit::manage_service {
-    # Puppet runs to enable the service are bugged
-    # on Puppet 4.X onwards for systemd
-    # See PUP-5296
-    # This is fixed but awaiting a Puppet 4.5 release
     service { $::cockpit::service_name:
-      ensure     => $::cockpit::service_ensure,
-      # enable     => true,
+      ensure => $::cockpit::service_ensure,
+      enable => true,
     }
   }
 }

--- a/spec/classes/cockpit_spec.rb
+++ b/spec/classes/cockpit_spec.rb
@@ -53,7 +53,7 @@ describe 'cockpit' do
 
     it { should contain_service('cockpit').with(
       :ensure => 'running',
-      # :enable => 'true'
+      :enable => 'true',
       )}
     it { should contain_package('cockpit').with_ensure('installed') }
 


### PR DESCRIPTION
* Previously disabled by default as there was a bug in Puppet < 4.5