### PR TITLE
Fixes repo configuration for Ubuntu

### DIFF
--- a/manifests/repo.pp
+++ b/manifests/repo.pp
@@ -8,10 +8,10 @@ class cockpit::repo {
       'RedHat': {
         case $::operatingsystem {
           'CentOS': {
-            require ::cockpit::repo::centos
+            contain ::cockpit::repo::centos
           }
           'Fedora': {
-            require ::cockpit::repo::fedora
+            contain ::cockpit::repo::fedora
           }
           default: {
             # code
@@ -21,10 +21,10 @@ class cockpit::repo {
       'Debian': {
         case $::operatingsystem {
           'Ubuntu': {
-            require ::cockpit::repo::ubuntu
+            contain ::cockpit::repo::ubuntu
           }
           'Debian': {
-            require ::cockpit::repo::debian
+            contain ::cockpit::repo::debian
           }
           default: {
             # code

--- a/manifests/repo/ubuntu.pp
+++ b/manifests/repo/ubuntu.pp
@@ -10,7 +10,7 @@ class cockpit::repo::ubuntu {
       id     => '637A2C82EDB1EF02DA658EE1046452EBC99782CC',
       server => 'keyserver.ubuntu.com',
     },
-    before   => Class['apt::update'],
+    notify   => Class['apt::update'],
   }
 
 }


### PR DESCRIPTION
* Previous config would give wrong order for the `apt update`:
```
Notice: /Stage[main]/Cockpit::Repo::Ubuntu/Apt::Ppa[ppa:cockpit-project/cockpit]/Exec[add-apt-repository-ppa:cockpit-project/cockpit]/returns: executed successfully
Info: /Stage[main]/Cockpit::Repo::Ubuntu/Apt::Ppa[ppa:cockpit-project/cockpit]/Exec[add-apt-repository-ppa:cockpit-project/cockpit]: Scheduling refresh of Class[Apt::Update]
Notice: /Stage[main]/Cockpit::Install/Package[cockpit]/ensure: created
Notice: /Stage[main]/Cockpit::Config/Ini_setting[Cockpit LoginTitle]/ensure: created
Notice: /Stage[main]/Cockpit::Config/Ini_setting[Cockpit MaxStartups]/ensure: created
Notice: /Stage[main]/Cockpit::Config/Ini_setting[Cockpit AllowUnencrypted]/ensure: created
Info: Class[Cockpit::Config]: Scheduling refresh of Class[Cockpit::Service]
Info: Class[Cockpit::Service]: Scheduling refresh of Service[cockpit]
Notice: /Stage[main]/Cockpit::Service/Service[cockpit]/ensure: ensure changed 'stopped' to 'running'
Info: /Stage[main]/Cockpit::Service/Service[cockpit]: Unscheduling refresh on Service[cockpit]
Info: Class[Apt::Update]: Scheduling refresh of Exec[apt_update]
Notice: /Stage[main]/Apt::Update/Exec[apt_update]: Triggered 'refresh' from 1 events
Notice: Applied catalog in 145.10 seconds
```