### PR TITLE
Replace legacy `validate_*` functions with datatypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+I have removed the upper limit on all module dependencies. This module may not work, but at least it won't break dependencies for everything else.
+
 # Cockpit Puppet Module
 [![Build Status](https://travis-ci.org/petems/petems-cockpit.svg?branch=master)](https://travis-ci.org/petems/petems-cockpit)
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -37,37 +37,19 @@
 #   install package. See https://copr.fedorainfracloud.org/coprs/g/cockpit/cockpit-preview/
 #
 class cockpit (
-  $allowunencrypted = $::cockpit::params::allowunencrypted,
-  $logintitle       = $::cockpit::params::logintitle,
-  $manage_package   = $::cockpit::params::manage_package,
-  $manage_repo      = $::cockpit::params::manage_repo,
-  $manage_service   = $::cockpit::params::manage_service,
-  $maxstartups      = $::cockpit::params::maxstartups,
-  $package_name     = $::cockpit::params::package_name,
-  $package_version  = $::cockpit::params::package_version,
-  $port             = $::cockpit::params::port,
-  $service_ensure   = $::cockpit::params::service_ensure,
-  $service_name     = $::cockpit::params::service_name,
-  $yum_preview_repo = $::cockpit::params::yum_preview_repo,
+  Boolean $allowunencrypted = $::cockpit::params::allowunencrypted,
+  String  $logintitle       = $::cockpit::params::logintitle,
+  Boolean $manage_package   = $::cockpit::params::manage_package,
+  Boolean $manage_repo      = $::cockpit::params::manage_repo,
+  Boolean $manage_service   = $::cockpit::params::manage_service,
+  String  $maxstartups      = $::cockpit::params::maxstartups,
+  String  $package_name     = $::cockpit::params::package_name,
+  String  $package_version  = $::cockpit::params::package_version,
+  Integer $port             = $::cockpit::params::port,
+  String  $service_ensure   = $::cockpit::params::service_ensure,
+  String  $service_name     = $::cockpit::params::service_name,
+  Boolean $yum_preview_repo = $::cockpit::params::yum_preview_repo,
 ) inherits ::cockpit::params {
-
-
-  validate_bool($allowunencrypted)
-  validate_bool($manage_package)
-  validate_bool($manage_repo)
-  validate_bool($manage_service)
-
-  validate_string($logintitle)
-  validate_string($maxstartups)
-  validate_string($package_name)
-  validate_string($package_version)
-  validate_string($service_ensure)
-  validate_string($service_name)
-
-  if ($port) {
-    validate_integer($port)
-  }
-
   class { '::cockpit::repo': } ->
   class { '::cockpit::install': } ->
   class { '::cockpit::config': } ~>

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
     {
       "operatingsystem": "Ubuntu",
       "operatingsystemrelease": [
-        "16.04"
+        "18.04"
       ]
     },
     {
@@ -51,21 +51,21 @@
     },
     {
       "name": "puppet",
-      "version_requirement": ">= 3.0.0 < 5.0.0"
+      "version_requirement": ">= 3.0.0"
     }
   ],
   "dependencies": [
     {
       "name": "puppetlabs-stdlib",
-      "version_requirement": ">= 4.11.0 <5.0.0"
+      "version_requirement": ">= 4.11.0"
     },
     {
       "name": "puppetlabs-apt",
-      "version_requirement": ">=2.3.0 <3.0.0"
+      "version_requirement": ">=2.3.0"
     },
     {
       "name": "puppetlabs-inifile",
-      "version_requirement": ">= 1.5.0 <2.0.0"
+      "version_requirement": ">= 1.5.0"
     }
   ]
 }


### PR DESCRIPTION
#### Pull Request (PR) description
`validate_*` has been deprecated as it is now covered by native Puppet data types and thus was removed from the latest `stdlib` [9.0.0](https://forge.puppet.com/modules/puppetlabs/stdlib/9.0.0/changelog#changed) causing a `Evaluation Error: Unknown function: 'validate_*'` error.